### PR TITLE
fixed YAML output

### DIFF
--- a/YAML_Doc.cpp
+++ b/YAML_Doc.cpp
@@ -31,8 +31,8 @@ YAML_Doc::~YAML_Doc(void){
 */
 string YAML_Doc::generateYAML(){
   string yaml;
-  yaml =  yaml + "Mini-Application Name_" + miniAppName + "\n";
-  yaml =  yaml + "Mini-Application Version_" + miniAppVersion + "\n";
+  yaml =  yaml + "Mini-Application Name: " + miniAppName + "\n";
+  yaml =  yaml + "Mini-Application Version: " + miniAppVersion + "\n";
   for(size_t i=0; i<children.size(); i++){
     yaml = yaml + children[i]->printYAML("");
   }


### PR DESCRIPTION
To make it YAML compatible, either use a colon or prefix the strings with '#' to mark it as comment. I vote for the colon version, as this can then be extracted using YAML parsers.